### PR TITLE
Setup Maven to generate reports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ local.properties
 # Eclipse Core
 .project
 
+# IntelliJ
+.idea
+
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
 

--- a/docs/project-description.md
+++ b/docs/project-description.md
@@ -1,0 +1,15 @@
+<!-- Brief description of your project. For example, What is it? How is the source-code organized? -->
+# JPass
+JPass is a simple, small, portable password manager application with strong encryption. It allows you to store user names, passwords, URLs and generic notes in an encrypted file protected by one master password.
+
+Features:
+
+- Strong encryption - AES-256-CBC algorithm (SHA-256 is used as password hash)
+- Portable - single jar file which can be carried on a USB stick
+- Built-in random password generator
+- Organize all your user name, password, URL and notes information in one file
+- Data import/export in XML format
+
+![JPass](https://raw.githubusercontent.com/gaborbata/jpass/master/resources/jpass-capture.png)
+
+## How to use

--- a/docs/project-description.md
+++ b/docs/project-description.md
@@ -13,3 +13,38 @@ Features:
 ![JPass](https://raw.githubusercontent.com/gaborbata/jpass/master/resources/jpass-capture.png)
 
 ## How to use
+
+
+## Source code structure
+
+The code repository has 3 folders (one of which - `docs` was added by us). In the `resources` folder, there are many `.png`, `.svg` and `.ico` files corresponding mostly to different JPass logotype dimensions and colors, as well as some other images regarding screenshots of the application itself. The `src` folder holds two sub-folders: `test` where some JUnit (not sure???) tests can be found and `main` where the code itself is present (`java` folder).
+
+---
+
+## Static testing
+
+Static testing is a way to assess whether the software was build right or not, i.e., if the system actually behaves according to the specification provided. It is utilized in order to check for existing faults in the software but, as the name implies, without executing the source code, being, for this reason, a key instrument in producing better quality software. 
+There are 2 types of static testing techniques: the reviews (manual procedures) and the ones in focus in this assignment: automated analysis tools.
+
+## Chosen static testing tools
+
+For this assignment we picked Checkstyle and Spotbugs as the static testing tools.
+
+TODO after:
+- how they were configured for the project: reason for enabling/disabling configurations
+
+## Reports
+
+### Checkstyle
+
+TODO
+
+### Spotbugs
+
+TODO
+
+### Selected bugs
+
+TODO: 5 bugs x 2 tools.
+- brief description of each.
+- fixes with before and after.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,21 @@
     <version>0.1.21-SNAPSHOT</version>
     <name>JPass</name>
     <properties>
+        <!-- Maven Related -->
+        <site.plugin.version>4.0.0-M3</site.plugin.version>
+        <javadoc.plugin.version>3.4.1</javadoc.plugin.version>
+        <dependency.plugin.version>3.3.0</dependency.plugin.version>
+        <jar.plugin.version>3.3.0</jar.plugin.version>
+        <projectinfo.plugin.version>2.9</projectinfo.plugin.version>
+        <jxr.plugin.version>3.3.0</jxr.plugin.version>
+        <shade.plugin.version>3.4.0</shade.plugin.version>
+        <surefire.plugin.version>3.0.0-M7</surefire.plugin.version>
+
+        <!-- Project related -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Project dependencies -->
+        <jacoco.plugin.version>0.8.8</jacoco.plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -91,6 +105,194 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.1.1</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <!-- This plugin will set properties values using dependency information -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${dependency.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${site.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${projectinfo.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${jar.plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test-files</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${shade.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>false</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- SpotBugs -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.7.2.0</version>
+            </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${site.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${projectinfo.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${javadoc.plugin.version}</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>${jxr.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+            </plugin>
+            <plugin> <!-- JUnit report -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
+            </plugin>
+
+            <!-- SpotBugs -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.7.2.0</version>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>


### PR DESCRIPTION
Set up necessary dependencies to generate report website.

Run `mvn site` to generate.

Known errors during execution:
```
[WARNING] Unable to process class META-INF/versions/9/module-info.class in JarAnalyzer File [UserPath]\.m2\repository\com\formdev\flatlaf\0.43\flatlaf-0.43.jar
org.apache.bcel.classfile.ClassFormatException: Invalid byte tag in constant pool: 19
...
[WARNING] An issue has occurred with maven-project-info-reports-plugin:2.9:dependency-info report, skipping LinkageError 'void org.apache.maven.doxia.sink.Sink.verbatim(boolean)', please report an issue to Maven dev team.
java.lang.NoSuchMethodError: 'void org.apache.maven.doxia.sink.Sink.verbatim(boolean)'
```