### PR TITLE
Bugfix: Changed value in Checkstyle configuration

### DIFF
--- a/rulesets/checkstyle-rules.xml
+++ b/rulesets/checkstyle-rules.xml
@@ -44,7 +44,7 @@
 
   <module name="LineLength">
     <property name="fileExtensions" value="java"/>
-    <property name="max" value="100"/>
+    <property name="max" value="150"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
   </module>
 


### PR DESCRIPTION
Due to the diversity of situations in which this warning was detected, it was considered a false-positive. An example is the situations such as long method declarations could be solved by renaming method parameters but that would maybe incur in confusing or unclear variable names.

Value for max number of characters per line for detection was changed to 150.

Fixes #11 