### PR TITLE
Bugfix: store clone of byte array instead of raw byte array.

### DIFF
--- a/src/main/java/jpass/data/DataModel.java
+++ b/src/main/java/jpass/data/DataModel.java
@@ -124,7 +124,7 @@ public class DataModel {
     }
 
     public void setPassword(byte[] password) {
-        this.password = password;
+        this.password = password.clone();
     }
 
     /**


### PR DESCRIPTION
Only password was vulnerable, other objects being stored in the instance are meant to stay mutable due to referencing output streams and similar.