### PR TITLE
[Test] jpass.util.StringUtils.stripNonValidXMLCharacters

### DIFF
--- a/src/test/java/jpass/util/StringUtilsTest.java
+++ b/src/test/java/jpass/util/StringUtilsTest.java
@@ -1,3 +1,5 @@
+package jpass.util;
+
 import static jpass.util.StringUtils.stripNonValidXMLCharacters;
 
 import java.util.Random;
@@ -7,7 +9,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 
-public class validXMLCharsTest {
+public class StringUtilsTest {
 
     String generateValidString() {
         int lowerBound = 32;     // Space
@@ -23,14 +25,14 @@ public class validXMLCharsTest {
 
 
     @Test
-    public void testNull() {
+    public void testNullStripNonValidXMLCharacters() {
         String nullOutput = stripNonValidXMLCharacters(null);
 
         Assertions.assertEquals("", nullOutput);
     }
 
     @Test
-    public void testEmptyStr() {
+    public void testEmptyStringStripNonValidXMLCharacters() {
         String emptyStr = "";
 
         String emptyOutput = stripNonValidXMLCharacters(emptyStr);
@@ -39,7 +41,7 @@ public class validXMLCharsTest {
     }
 
     @RepeatedTest(10)
-    public void testValidInput() {
+    public void testValidInputStripNonValidXMLCharacters() {
         String alphaNumeric = generateValidString();
 
         String output = stripNonValidXMLCharacters(alphaNumeric);
@@ -48,7 +50,7 @@ public class validXMLCharsTest {
     }
 
     @Test
-    public void testInvalidInput() {
+    public void testInvalidInputStripNonValidXMLCharacters() {
         String invalidChar = "\uD800\uDC00"; // Unicode Character 'LINEAR B SYLLABLE B008 A' (U+10000)
 
         String output = stripNonValidXMLCharacters(invalidChar);

--- a/src/test/java/validXMLCharsTest.java
+++ b/src/test/java/validXMLCharsTest.java
@@ -9,19 +9,16 @@ import org.junit.jupiter.api.Test;
 
 public class validXMLCharsTest {
 
-    String generateAlphanumeric() {
-        int leftLimit = 48; // numeral '0'
-        int rightLimit = 122; // letter 'z'
-        int targetStringLength = 20;
+    String generateValidString() {
+        int lowerBound = 32;     // Space
+        int upperBound = 126;   // '~'
+        int stringLength = 25;
         Random random = new Random();
 
-        String generatedString = random.ints(leftLimit, rightLimit + 1)
-                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
-                .limit(targetStringLength)
+        return random.ints(lowerBound, upperBound + 1)
+                .limit(stringLength)
                 .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
                 .toString();
-
-        return generatedString;
     }
 
 
@@ -43,7 +40,7 @@ public class validXMLCharsTest {
 
     @RepeatedTest(10)
     public void testValidInput() {
-        String alphaNumeric = generateAlphanumeric();
+        String alphaNumeric = generateValidString();
 
         String output = stripNonValidXMLCharacters(alphaNumeric);
 

--- a/src/test/java/validXMLCharsTest.java
+++ b/src/test/java/validXMLCharsTest.java
@@ -1,0 +1,65 @@
+import static jpass.util.StringUtils.stripNonValidXMLCharacters;
+
+import java.nio.charset.Charset;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Input: string
+ */
+public class validXMLCharsTest {
+
+    String generateAlphanumeric() {
+        int leftLimit = 48; // numeral '0'
+        int rightLimit = 122; // letter 'z'
+        int targetStringLength = 20;
+        Random random = new Random();
+
+        String generatedString = random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+
+        return generatedString;
+    }
+
+
+    @Test
+    public void testingNullAndEmpty() {
+        String nullStr = null;
+        String emptyStr = "";
+
+        String nullOutput = stripNonValidXMLCharacters(nullStr);
+        String emptyOutput = stripNonValidXMLCharacters(emptyStr);
+
+        Assert.assertEquals("", nullOutput);
+        Assert.assertEquals("", emptyOutput);
+    }
+
+    @Test
+    public void testingAlphanumeric() {
+        String alphaNumeric, output;
+        int nTries = 50;
+
+        for (int i = 0; i < nTries; i++) {
+            alphaNumeric = generateAlphanumeric();
+            output = stripNonValidXMLCharacters(alphaNumeric);
+            System.out.println(alphaNumeric);
+            Assert.assertEquals(alphaNumeric, output);
+        }
+    }
+
+    @Test
+    public void idk() {
+        byte[] array = new byte[7]; // length is bounded by 7
+        new Random().nextBytes(array);
+        String generatedString = new String(array, Charset.forName("UTF-8"));
+        String output = stripNonValidXMLCharacters(generatedString);
+
+        Assert.assertEquals(generatedString, output);
+    }
+}

--- a/src/test/java/validXMLCharsTest.java
+++ b/src/test/java/validXMLCharsTest.java
@@ -1,5 +1,6 @@
 import static jpass.util.StringUtils.stripNonValidXMLCharacters;
 
+import java.lang.annotation.Repeatable;
 import java.nio.charset.Charset;
 import java.util.Random;
 import java.util.UUID;
@@ -48,18 +49,28 @@ public class validXMLCharsTest {
         for (int i = 0; i < nTries; i++) {
             alphaNumeric = generateAlphanumeric();
             output = stripNonValidXMLCharacters(alphaNumeric);
-            System.out.println(alphaNumeric);
+            // System.out.println(alphaNumeric);
             Assert.assertEquals(alphaNumeric, output);
         }
     }
 
     @Test
-    public void idk() {
-        byte[] array = new byte[7]; // length is bounded by 7
-        new Random().nextBytes(array);
-        String generatedString = new String(array, Charset.forName("UTF-8"));
-        String output = stripNonValidXMLCharacters(generatedString);
+    public void testingInvalid() {
+        String invalidChar = "\uD800\uDC00"; // Unicode Character 'LINEAR B SYLLABLE B008 A' (U+10000)
+        String output = stripNonValidXMLCharacters(invalidChar);
 
-        Assert.assertEquals(generatedString, output);
+        Assert.assertNotEquals(invalidChar, output);
+    }
+
+    @Test
+    public void testingValidAndInvalid() {
+        for (int i = 0; i < 10; i++) {
+            String str = generateAlphanumeric();
+            str += "-\uD806\uDE00";
+
+            String output = stripNonValidXMLCharacters(str);
+
+            Assert.assertNotEquals(str, output);
+        }
     }
 }

--- a/src/test/java/validXMLCharsTest.java
+++ b/src/test/java/validXMLCharsTest.java
@@ -1,16 +1,11 @@
 import static jpass.util.StringUtils.stripNonValidXMLCharacters;
 
-import java.lang.annotation.Repeatable;
-import java.nio.charset.Charset;
 import java.util.Random;
-import java.util.UUID;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-/**
- * Input: string
- */
+
 public class validXMLCharsTest {
 
     String generateAlphanumeric() {
@@ -30,47 +25,40 @@ public class validXMLCharsTest {
 
 
     @Test
-    public void testingNullAndEmpty() {
+    public void testNull() {
         String nullStr = null;
-        String emptyStr = "";
 
         String nullOutput = stripNonValidXMLCharacters(nullStr);
+
+        Assertions.assertEquals("", nullOutput);
+    }
+
+    @Test
+    public void testEmptyStr() {
+        String emptyStr = "";
+
         String emptyOutput = stripNonValidXMLCharacters(emptyStr);
 
-        Assert.assertEquals("", nullOutput);
-        Assert.assertEquals("", emptyOutput);
+        Assertions.assertEquals("", emptyOutput);
     }
 
     @Test
-    public void testingAlphanumeric() {
-        String alphaNumeric, output;
-        int nTries = 50;
+    public void testValidInput() {
+        String alphaNumeric = generateAlphanumeric();
+        String output;
 
-        for (int i = 0; i < nTries; i++) {
-            alphaNumeric = generateAlphanumeric();
-            output = stripNonValidXMLCharacters(alphaNumeric);
-            // System.out.println(alphaNumeric);
-            Assert.assertEquals(alphaNumeric, output);
-        }
+        output = stripNonValidXMLCharacters(alphaNumeric);
+
+        Assertions.assertEquals(alphaNumeric, output);
     }
 
     @Test
-    public void testingInvalid() {
+    public void testInvalidInput() {
         String invalidChar = "\uD800\uDC00"; // Unicode Character 'LINEAR B SYLLABLE B008 A' (U+10000)
+
         String output = stripNonValidXMLCharacters(invalidChar);
 
-        Assert.assertNotEquals(invalidChar, output);
+        Assertions.assertNotEquals(invalidChar, output);
     }
 
-    @Test
-    public void testingValidAndInvalid() {
-        for (int i = 0; i < 10; i++) {
-            String str = generateAlphanumeric();
-            str += "-\uD806\uDE00";
-
-            String output = stripNonValidXMLCharacters(str);
-
-            Assert.assertNotEquals(str, output);
-        }
-    }
 }

--- a/src/test/java/validXMLCharsTest.java
+++ b/src/test/java/validXMLCharsTest.java
@@ -3,6 +3,7 @@ import static jpass.util.StringUtils.stripNonValidXMLCharacters;
 import java.util.Random;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 
@@ -26,9 +27,7 @@ public class validXMLCharsTest {
 
     @Test
     public void testNull() {
-        String nullStr = null;
-
-        String nullOutput = stripNonValidXMLCharacters(nullStr);
+        String nullOutput = stripNonValidXMLCharacters(null);
 
         Assertions.assertEquals("", nullOutput);
     }
@@ -42,12 +41,11 @@ public class validXMLCharsTest {
         Assertions.assertEquals("", emptyOutput);
     }
 
-    @Test
+    @RepeatedTest(10)
     public void testValidInput() {
         String alphaNumeric = generateAlphanumeric();
-        String output;
 
-        output = stripNonValidXMLCharacters(alphaNumeric);
+        String output = stripNonValidXMLCharacters(alphaNumeric);
 
         Assertions.assertEquals(alphaNumeric, output);
     }


### PR DESCRIPTION
Added unit tests for the `stripNonValidXMLCharacters` method.

### Method Purpose
`stripNonValidXMLCharacters` ensures that its output is composed only of valid XML characters described by [W3C documentation](https://www.w3.org/TR/xml/#NT-Char) except for characters outside the UTF-16 BMP, since the changed made in the relevant [issue](https://github.com/Telmooo/jpass/issues/3) to the documentation and behaviour of the method.

### Category-Partition
There is a single parameter - `final String in` - and an output (method return value) of the same class: `String`, and there aren't any restrictions in the contents or length of the parameter (except the theoretical maximum of 2 147 483 647 characters), nor exceptional behaviour.

As the function's goal is to output a string composed only of valid XML characters, and by looking at the documentation provided, the following division was reached:
1. the null case - where, according to the documentation, an empty string should be output;
2. the empty string - with expected behaviour identical to the null case;
3. valid input - input string with only valid characters, where it is expected that the input and output are identical. For this case, it was utilized an auxiliary method that generated a random string (with valid characters);
4. invalid input - input string with only invalid characters, where differences are expected between the input and output.

Test cases for the partitions described above were developed in this PR as follows:
1. Test is done by passing a null string as input of the method;
2. Test is done by passing an empty string as input of the method;
3. Test is set up with a repeated test, cycling random generated strings containing only valid characters by our specification, and testing for equality of strings, as no character should be switched;
4. Test is set up with the surrogate character mentioned in the [issue](https://github.com/Telmooo/jpass/issues/3) that addressed the behaviour of this method, and is tested for inequality of the strings (original and stripped).

All tests yielded the expected results (all passed):
1. an empty string `""` was returned;
2. an empty string `""` was returned;
3. the equality comparison between the input and output strings return `true`;
5. the inequality comparison between the input and output returned `true`. The invalid characters of the input were in fact changed to question marks and, therefore, printing the output would show `?` characters.

Note regarding the 3rd case: even though it was most likely not necessary (due to the fact that it is usually expected that if an "a" is valid, a "b" will also be), test repetition was implemented for learning purposes (with a value of 10) as it didn't represent a relevant impact on performance (a few milliseconds, according to IntelliJ).