### PR TITLE
[Test] jpass.util.ClipboardUtils.getClipboardContent

### DIFF
--- a/src/test/java/jpass/util/ClipboardUtilsTest.java
+++ b/src/test/java/jpass/util/ClipboardUtilsTest.java
@@ -1,0 +1,89 @@
+package jpass.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.awt.datatransfer.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+public class ClipboardUtilsTest {
+
+    private final class EmptyClipboard implements Transferable, ClipboardOwner {
+
+            @Override
+            public DataFlavor[] getTransferDataFlavors() {
+                return new DataFlavor[0];
+            }
+
+            @Override
+            public boolean isDataFlavorSupported(DataFlavor flavor) {
+                return false;
+            }
+
+            @Override
+            public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
+                throw new UnsupportedFlavorException(flavor);
+            }
+            @Override
+            public void lostOwnership(Clipboard clipboard, Transferable contents) {  }
+    }
+
+    private final EmptyClipboard emptyClipboard = new EmptyClipboard();
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(emptyClipboard, emptyClipboard);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(emptyClipboard, emptyClipboard);
+    }
+
+    @Test
+    public void testGetEmptyClipboardContent() {
+        Assertions.assertNull(ClipboardUtils.getClipboardContent());
+    }
+
+    @Test
+    public void testGetTextClipboardContent() {
+        StringSelection selection = new StringSelection("a text string");
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(selection, selection);
+
+        Assertions.assertEquals("a text string", ClipboardUtils.getClipboardContent());
+    }
+
+    @Test
+    public void testGetNonTextClipboardContent() {
+        BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(
+                new Transferable() {
+                    @Override
+                    public DataFlavor[] getTransferDataFlavors() {
+                        return new DataFlavor[] { DataFlavor.imageFlavor };
+                    }
+
+                    @Override
+                    public boolean isDataFlavorSupported(DataFlavor flavor) {
+                        return flavor == DataFlavor.imageFlavor;
+                    }
+
+                    @Override
+                    public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+                        if (isDataFlavorSupported(flavor)) {
+                            return image;
+                        } else {
+                            throw new UnsupportedFlavorException(flavor);
+                        }
+                    }
+                }, null
+        );
+
+        Assertions.assertNull(ClipboardUtils.getClipboardContent());
+    }
+}


### PR DESCRIPTION
Added unit testing for method `getClipboardContent`.

# Method Purpose
`getClipboardContent` extracts the current text stored in the system clipboard, if available.

# Category-Partition
This method takes no arguments, has no exceptional behaviour, and returns a String object containing the text content of the system clipboard, if available and exists, returning `null` otherwise.
With this in mind, we can obtain the following partitions for testing:
1. the empty clipboard case - where the system clipboard is completely empty and has no content, and therefore, should make the method return `null`;
2. clipboard with text content - where the system clipboard contains valid text content, and therefore, should make the method return that text;
3. clipboard with non-text content - where the system clipboard contains non-valid text content, such as, an image, a file, or similar, and therefore, should make the method return `null`.

Test cases for the partitions described above were developed in this PR as follows:
1. Test is done with a cleared clipboard;
2. Test is set up with a clipboard containing a string `a text string`;
3. Test is set up with a clipboard containing a random image;

Method behaved as expected for all the tests developed:
1. Properly returned `null` as expected;
2. Properly returned the content of the clipboard, `a text string`, as expected;
3. Properly returned `null`, as the content of the clipboard is not a valid text content.