### PR TITLE
[Test] java.util.CryptUtils.getPKCS5Sha256Hash

### DIFF
--- a/src/test/java/jpass/util/CryptUtilsTest.java
+++ b/src/test/java/jpass/util/CryptUtilsTest.java
@@ -1,0 +1,42 @@
+package jpass.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+class CryptUtilsTest {
+
+    @Test
+    void testGetPKCS5Sha256Hash() throws Exception {
+        byte[] expectedHash = {
+                // "the cake is a lie" => 652D99FE88A68271D3B6414B6673FB80A0A3FA96B10E4D83FDB1B8AA8B65BC1E
+                (byte) 0x65, (byte) 0x2D, (byte) 0x99, (byte) 0xFE, (byte) 0x88, (byte) 0xA6, (byte) 0x82, (byte) 0x71,
+                (byte) 0xD3, (byte) 0xB6, (byte) 0x41, (byte) 0x4B, (byte) 0x66, (byte) 0x73, (byte) 0xFB, (byte) 0x80,
+                (byte) 0xA0, (byte) 0xA3, (byte) 0xFA, (byte) 0x96, (byte) 0xB1, (byte) 0x0E, (byte) 0x4D, (byte) 0x83,
+                (byte) 0xFD, (byte) 0xB1, (byte) 0xB8, (byte) 0xAA, (byte) 0x8B, (byte) 0x65, (byte) 0xBC, (byte) 0x1E,
+        };
+
+        Assertions.assertArrayEquals(expectedHash, CryptUtils.getPKCS5Sha256Hash("the cake is a lie".toCharArray()));
+    }
+
+    @Test
+    void testGetNullPKCS5Sha256Hash() {
+        Assertions.assertThrows(Exception.class, () -> {
+            CryptUtils.getPKCS5Sha256Hash(null);
+        });
+    }
+
+    @Test
+    void testGetEmptyPKCS5Sha256Hash() throws Exception {
+        byte[] expectedHash = {
+                // empty char array => 0DC9B0E0900F0CE71F36C359CBCF968D6366F2762F5699A2F5EA5FDCCB70F0C8
+                (byte) 0x0D, (byte) 0xC9, (byte) 0xB0, (byte) 0xE0, (byte) 0x90, (byte) 0x0F, (byte) 0x0C, (byte) 0xE7,
+                (byte) 0x1F, (byte) 0x36, (byte) 0xC3, (byte) 0x59, (byte) 0xCB, (byte) 0xCF, (byte) 0x96, (byte) 0x8D,
+                (byte) 0x63, (byte) 0x66, (byte) 0xF2, (byte) 0x76, (byte) 0x2F, (byte) 0x56, (byte) 0x99, (byte) 0xA2,
+                (byte) 0xF5, (byte) 0xEA, (byte) 0x5F, (byte) 0xDC, (byte) 0xCB, (byte) 0x70, (byte) 0xF0, (byte) 0xC8,
+        };
+
+        Assertions.assertArrayEquals(expectedHash, CryptUtils.getPKCS5Sha256Hash(new char[0]));
+    }
+}

--- a/src/test/java/jpass/util/CryptUtilsTest.java
+++ b/src/test/java/jpass/util/CryptUtilsTest.java
@@ -22,9 +22,7 @@ class CryptUtilsTest {
 
     @Test
     void testGetNullPKCS5Sha256Hash() {
-        Assertions.assertThrows(Exception.class, () -> {
-            CryptUtils.getPKCS5Sha256Hash(null);
-        });
+        Assertions.assertThrows(Exception.class, () -> CryptUtils.getPKCS5Sha256Hash(null));
     }
 
     @Test


### PR DESCRIPTION
Added unit testing for method `getPKCS5Sha256Hash`.

# Method Purpose
`getPKCS5Sha256Hash` calculates the SHA-256 hash with 1000 iterations of the input char array.

# Category-Partition
This method takes a single argument, the input text in `char[]` format, has exceptional behaviour, in which, it will throw an exception if any exception occurs during the hashing process, and returns the hashed result in `byte[]` format.

With this in mind, we can obtain the following partitions for testing:
1. the empty array case - in which the input array is an empty char array;
2. non-empty char array - in which the input array is any non-empty text in char array format;
3. null char array - in which the input array is a null char array.

Test cases for the partitions described above were developed in this PR as follows:
1. Test is done with an empty char array `new char[0]`;
2. Test is set up with a text in char array format, such as, [`the cake is a lie`](https://www.youtube.com/watch?v=qdrs3gr_GAs);
3. Test is set up with a clipboard containing a random image;

Method behaved as expected for all the tests developed:
1. Properly returned the correspondent 1000th iteration of SHA-256 hash of an empty text, which is not an empty hash, as expected;
2. Properly returned the correspondent 1000th iteration of SHA-256 hash of the input string [`the cake is a lie`](https://www.youtube.com/watch?v=qdrs3gr_GAs), as expected;
3. Throws an exception due to `NullPointerException`. Which is the expected result, given the method declaration denoting a possible exceptional behaviour.

Notes:
For test case 3, it was assumed that throwing an exception was the intended behaviour, as this method doesn't provide documentation for expected behaviour when facing a null input.